### PR TITLE
Change open_file to with set_timeout

### DIFF
--- a/related_files.py
+++ b/related_files.py
@@ -96,7 +96,7 @@ class RelatedFilesCommand(sublime_plugin.WindowCommand):
     # Opens the file in path.
     def __open_file(self, index):
         if index >= 0:
-            self.window.open_file(self.__related.files()[index])
+            sublime.set_timeout(lambda: self.window.open_file(self.__related.files()[index]), 0)
         else:
             self.__status_msg("No related files found")
 


### PR DESCRIPTION
Thank you for a great feature! 

I am using Sublime Text Version 3 (Build 3059), but there may not be the focus after the file is opened. 
If use `set_timeout`, fixed.

Please merge if it is good.

Ref:
https://github.com/SublimeText/Issues/issues/39
