### PR TITLE
Add create_new_files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The configuration has two parts: the key, which is a regular expression to match
 
 You can use the $1, $2, etc. on the glob strings to be replace by the extracted parts from the regex.
 
+If the "create_new_files" option is set to true, matches will appear for files that do not yet exist, allowing
+you to create them.
+
 In addition to global configs, you can also have per project configs. To add that, in a sublime project file (project-name.sublime-project),
 add this:
 

--- a/RelatedFiles.sublime-settings
+++ b/RelatedFiles.sublime-settings
@@ -1,4 +1,6 @@
 {
+  "create_new_files": false,
+
   "patterns": {
     // Test/specs for ruby files
     ".+\/(app|lib)\/(.+).rb":

--- a/related_files.py
+++ b/related_files.py
@@ -105,7 +105,10 @@ class RelatedFilesCommand(sublime_plugin.WindowCommand):
     # Opens the file in path.
     def __open_file(self, index):
         if index >= 0:
-            self.window.open_file(self.__related.files()[index])
+            selected_file = self.__related.files()[index]
+            if not os.path.isdir(os.path.dirname(selected_file)):
+                os.makedirs(os.path.dirname(selected_file))
+            self.window.open_file(selected_file)
         else:
             self.__status_msg("No related files found")
 

--- a/related_files.py
+++ b/related_files.py
@@ -117,7 +117,6 @@ class RelatedFilesCommand(sublime_plugin.WindowCommand):
             selected_file = self.__related.files()[index]
             if not os.path.isdir(os.path.dirname(selected_file)):
                 os.makedirs(os.path.dirname(selected_file))
-            self.window.open_file(selected_file)
             sublime.set_timeout(lambda: self.window.open_file(selected_file), 0)
         else:
             self.__status_msg("No related files found")

--- a/related_files.py
+++ b/related_files.py
@@ -56,8 +56,11 @@ class Related(object):
     def __files_for_paths(self, regex, match, paths):
         paths = [self.__replaced_path(match, path) for path in paths]
 
-        files = [glob.glob(os.path.join(self.__root, path)) for path in paths]
-        flattened = [self.__to_posixpath(path) for path in list(itertools.chain.from_iterable(files))]
+        if self.__create_new_files_option_enabled():
+            flattened = [self.__to_posixpath(path) for path in paths if not self.__path_contains_wildcard(path)]
+        else:
+            files = [glob.glob(os.path.join(self.__root, path)) for path in paths]
+            flattened = [self.__to_posixpath(path) for path in list(itertools.chain.from_iterable(files))]
 
         # Ignores current file
         if self.__file_path in flattened:
@@ -80,6 +83,12 @@ class Related(object):
     # Converts paths to posixpaths.
     def __to_posixpath(self, path):
         return re.sub("\\\\", "/", path)
+
+    def __create_new_files_option_enabled(self):
+        return sublime.load_settings("RelatedFiles.sublime-settings").get('create_new_files')
+
+    def __path_contains_wildcard(self, path):
+        return '**' in path
 
 class RelatedFilesCommand(sublime_plugin.WindowCommand):
     def run(self, index=None):

--- a/related_files.py
+++ b/related_files.py
@@ -57,7 +57,16 @@ class Related(object):
         paths = [self.__replaced_path(match, path) for path in paths]
 
         if self.__create_new_files_option_enabled():
-            flattened = [self.__to_posixpath(path) for path in paths if not self.__path_contains_wildcard(path)]
+            non_wildcard_matches = [
+                self.__to_posixpath(path) for path in paths if not self.__path_contains_wildcard(path)
+            ]
+
+            wildcard_matches = [
+                glob.glob(os.path.join(self.__root, path)) for path in paths if self.__path_contains_wildcard(path)
+            ]
+
+            flattened = [self.__to_posixpath(path) for path in list(itertools.chain.from_iterable(wildcard_matches))]
+            flattened.extend(non_wildcard_matches)
         else:
             files = [glob.glob(os.path.join(self.__root, path)) for path in paths]
             flattened = [self.__to_posixpath(path) for path in list(itertools.chain.from_iterable(files))]


### PR DESCRIPTION
Hi. I created this fork over a year ago and have been using it personally. I finally decided that it was worth a PR. It adds a create_new_files option that is disabled by default. When enabled, matches will appear even if the related file does not exist. Selecting one of these matches will create the related file.
